### PR TITLE
fix #5 (global name 'Authorizer' is not defined)

### DIFF
--- a/ckanext/googleanalytics/dbutil.py
+++ b/ckanext/googleanalytics/dbutil.py
@@ -79,7 +79,6 @@ def get_resource_visits_for_url(url):
 
 def get_top_packages(limit=20):
     items = []
-    authorizer = Authorizer()
     # caveat emptor: the query below will not filter out private
     # or deleted datasets (TODO)
     q = model.Session.query(model.Package)

--- a/ckanext/googleanalytics/dbutil.py
+++ b/ckanext/googleanalytics/dbutil.py
@@ -80,8 +80,9 @@ def get_resource_visits_for_url(url):
 def get_top_packages(limit=20):
     items = []
     authorizer = Authorizer()
-    q = authorizer.authorized_query(PSEUDO_USER__VISITOR,
-                                    model.Package)
+    # caveat emptor: the query below will not filter out private
+    # or deleted datasets (TODO)
+    q = model.Session.query(model.Package)
     connection = model.Session.connection()
     package_stats = get_table('package_stats')
     s = select([package_stats.c.package_id,


### PR DESCRIPTION
This will run without exceptions. Beware that private or deleted datasets might show up as the athorization step for PSEUDO_USER__VISITOR has been bypassed. Consider this as a quick fix that might not be usable in every circumstance.
