### PR TITLE
Declare namespace in ckanext/googleanalytics/__init__.py

### DIFF
--- a/ckanext/googleanalytics/__init__.py
+++ b/ckanext/googleanalytics/__init__.py
@@ -1,1 +1,7 @@
-#
+# this is a namespace package
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
Fix for Namespace package problem. Now the extension can be installed with setuptools.
