### PR TITLE
Remove calls to get_top_packages

### DIFF
--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -23,7 +23,6 @@ log = logging.getLogger('ckanext.googleanalytics')
 class GAController(BaseController):
     def view(self):
         # get package objects corresponding to popular GA content
-        c.top_packages = dbutil.get_top_packages(limit=10)
         c.top_resources = dbutil.get_top_resources(limit=10)
         return render('summary.html')
 

--- a/ckanext/googleanalytics/dbutil.py
+++ b/ckanext/googleanalytics/dbutil.py
@@ -3,7 +3,7 @@ from sqlalchemy.sql import select, text
 from sqlalchemy import func
 
 import ckan.model as model
-from ckan.model.authz import PSEUDO_USER__VISITOR
+# from ckan.model.authz import PSEUDO_USER__VISITOR
 from ckan.lib.base import *
 
 cached_tables = {}
@@ -76,7 +76,11 @@ def get_resource_visits_for_url(url):
         AND resource.url = :url"""), url=url).fetchone()
     return count and count[0] or ""
 
+""" get_top_packages is broken, and needs to be rewritten to work with
+CKAN 2.*. This is because ckan.authz has been removed in CKAN 2.*
 
+See commit ffa86c010d5d25fa1881c6b915e48f3b44657612
+"""
 def get_top_packages(limit=20):
     items = []
     authorizer = Authorizer()


### PR DESCRIPTION
get_top_packages is broken, and needs to be rewritten to work with
CKAN 2.*. This is because ckan.authz has been removed in CKAN 2.*

See commit ffa86c010d5d25fa1881c6b915e48f3b44657612