### PR TITLE
Add support for Google Analytics domain linking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,15 @@ Installation
 
    ``fields`` allows you to specify various options when creating the tracker. See `Google's documentation <https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference>`.
 
+Domain Linking
+--------------
+
+This plugin supports cross-domain tracking using Googles' site linking feature.
+
+To use this, set the ``googleanalytics.linked_domains`` configuration option to a (comma seperated) list of domains to report for.
+
+See `Googles' documentation<https://support.google.com/analytics/answer/1034342?hl=en>`_ for more information
+
 Setting Up Statistics Retrieval from Google Analytics
 -----------------------------------------------------
 

--- a/ckanext/googleanalytics/plugin.py
+++ b/ckanext/googleanalytics/plugin.py
@@ -67,6 +67,13 @@ class GoogleAnalyticsPlugin(p.SingletonPlugin):
                 'googleanalytics.domain', 'auto')
         self.googleanalytics_fields = ast.literal_eval(config.get(
             'googleanalytics.fields', '{}'))
+
+        self.googleanalytics_linked_domains = [x.strip() for x in config.get(
+            'googleanalytics.linked_domains', ''
+        ).split(',')]
+        if self.googleanalytics_linked_domains:
+            self.googleanalytics_fields['allowLinker'] = True
+
         self.googleanalytics_javascript_url = h.url_for_static(
                 '/scripts/ckanext-googleanalytics.js')
 
@@ -194,8 +201,11 @@ class GoogleAnalyticsPlugin(p.SingletonPlugin):
         templates in this extension, see ITemplateHelpers.
 
         '''
-        data = {'googleanalytics_id': self.googleanalytics_id,
-                'googleanalytics_domain': self.googleanalytics_domain,
-                'googleanalytics_fields': str(self.googleanalytics_fields)}
+        data = {
+            'googleanalytics_id': self.googleanalytics_id,
+            'googleanalytics_domain': self.googleanalytics_domain,
+            'googleanalytics_fields': str(self.googleanalytics_fields),
+            'googleanalytics_linked_domains': self.googleanalytics_linked_domains
+        }
         return p.toolkit.render_snippet(
             'googleanalytics/snippets/googleanalytics_header.html', data)

--- a/ckanext/googleanalytics/templates/googleanalytics/snippets/googleanalytics_header.html
+++ b/ckanext/googleanalytics/templates/googleanalytics/snippets/googleanalytics_header.html
@@ -5,6 +5,10 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{googleanalytics_id}}', '{{googleanalytics_domain}}', {{googleanalytics_fields|safe}});
+  {% if googleanalytics_linked_domains %}
+  ga('require', 'linker');
+  ga('linker:autoLink', [{% for domain in googleanalytics_linked_domains %}'{{domain}}'{% if not loop.last %},{% endif %}{% endfor %}] );
+  {% endif %}   
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 </script>


### PR DESCRIPTION
This allows for cross-domain tracking. See Google documentation for more detail:
https://support.google.com/analytics/answer/1034342?hl=en