### PR TITLE
Fix a bug introduced in #25

### DIFF
--- a/ckanext/googleanalytics/plugin.py
+++ b/ckanext/googleanalytics/plugin.py
@@ -72,7 +72,7 @@ class GoogleAnalyticsPlugin(p.SingletonPlugin):
             'googleanalytics.linked_domains', ''
         ).split(',')]
         if self.googleanalytics_linked_domains:
-            self.googleanalytics_fields['allowLinker'] = True
+            self.googleanalytics_fields['allowLinker'] = 'true'
 
         self.googleanalytics_javascript_url = h.url_for_static(
                 '/scripts/ckanext-googleanalytics.js')


### PR DESCRIPTION
Setting a googleanalytics_fields key to `True` as in #25 causes the resulting Javascript to also include the literal `True`, which is not valid. 
This works around that by setting the key to `'true'` which when evaluated in an if statement is truthy, serving the same purpose

I also tried using `{{h.dump_json(googleanalytics_fields)|safe}}` and loading that in using `JSON.parse`, but `h.dump_json` seems to return invalid JSON when used in a template