### PR TITLE
Fix error that causes downloading stats from GA to fail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ Installation
       googleanalytics.domain = auto
       googleanalytics.track_events = false
       googleanalytics.fields = {}
+      googleanalytics.enable_user_id = false
 
    ``resource_prefix`` is an arbitrary identifier so that we can query
    for downloads in Google Analytics.  It can theoretically be any
@@ -115,6 +116,10 @@ Installation
    pages as well.*
 
    ``fields`` allows you to specify various options when creating the tracker. See `Google's documentation <https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference>`.
+
+   If ``enable_user_id`` is set to ``true``, then logged in users will be tracked into the Google Analytics' dashboard.
+   This way metrics can be tracked for every logged in user. You can read more
+   about this feature and its benefits `here <https://support.google.com/analytics/answer/3123662>`_.
 
 Domain Linking
 --------------

--- a/ckanext/googleanalytics/ga_auth.py
+++ b/ckanext/googleanalytics/ga_auth.py
@@ -51,14 +51,14 @@ def get_profile_id(service):
         if acc.get('name') == accountName:
             accountId = acc.get('id')
 
-    # TODO: check, whether next line is doing something useful.
-    webproperties = service.management().webproperties().list(
-        accountId=accountId).execute()
+            # TODO: check, whether next line is doing something useful.
+            webproperties = service.management().webproperties().list(
+                accountId=accountId).execute()
 
-    profiles = service.management().profiles().list(
-        accountId=accountId, webPropertyId=webPropertyId).execute()
+            profiles = service.management().profiles().list(
+                accountId=accountId, webPropertyId=webPropertyId).execute()
 
-    if profiles.get('items'):
-        return profiles.get('items')[0].get('id')
+            if profiles.get('items'):
+                return profiles.get('items')[0].get('id')
 
     return None

--- a/ckanext/googleanalytics/plugin.py
+++ b/ckanext/googleanalytics/plugin.py
@@ -137,6 +137,8 @@ class GoogleAnalyticsPlugin(p.SingletonPlugin):
             config.get('googleanalytics.show_downloads', True))
         self.track_events = converters.asbool(
             config.get('googleanalytics.track_events', False))
+        self.enable_user_id = converters.asbool(
+            config.get('googleanalytics.enable_user_id', False))
 
         if not converters.asbool(config.get('ckan.legacy_templates', 'false')):
             p.toolkit.add_resource('fanstatic_library', 'ckanext-googleanalytics')
@@ -243,6 +245,10 @@ class GoogleAnalyticsPlugin(p.SingletonPlugin):
         templates in this extension, see ITemplateHelpers.
 
         '''
+
+        if self.enable_user_id and c.user:
+            self.googleanalytics_fields['userId'] = str(c.userobj.id)
+
         data = {
             'googleanalytics_id': self.googleanalytics_id,
             'googleanalytics_domain': self.googleanalytics_domain,


### PR DESCRIPTION
The old version references  the variable `accountId` even if it isn't assigned in the preceding if statement. Indenting the relevant code block so it's only called if `accountId` is assigned resolves the error.