### PR TITLE
Add a MANIFEST.in file to allow using the plugin through `pip install`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+include LICENSE.txt
+include requirements.txt
+recursive-include ckanext/googleanalytics *.html *.js


### PR DESCRIPTION
This PR adds a `MANIFEST.in` file so that when the package is installed using `pip install` the html templates are correctly copied to the `dist-packages` directory.

Without this, only the `.py` files are taken into account, which means the extension is unusable (no modification of the UI).

Thanks!