### PR TITLE
WIP: Send GA custom dimension parameter for better report

### DIFF
--- a/ckanext/googleanalytics/plugin/__init__.py
+++ b/ckanext/googleanalytics/plugin/__init__.py
@@ -47,7 +47,9 @@ class AnalyticsPostThread(threading.Thread):
             log.debug("Sending API event to Google Analytics: " + data)
             # send analytics
             res = requests.post(
-                "http://www.google-analytics.com/collect", data, timeout=10,
+                "http://www.google-analytics.com/collect", data,
+                headers={'user-agent': 'CPython/2.7'},
+                timeout=10,
             )
             # signals to queue job is done
             self.queue.task_done()


### PR DESCRIPTION
-  Found it is not submitting to GA without a user agent so, added a user agent on the headers.
-  Send GA parameter with custom dimension  (organization, package, resource name) while accessing package/resource/datastore level APIs. 

