### PR TITLE
support python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 gdata>=2.0.0
 google-api-python-client>=1.6.1, <1.7.0
 pyOpenSSL>=16.2.0
+rsa>=3.1.4, <=4.0


### PR DESCRIPTION
rsa package does not support python 2.7 above v4.0
Fixes #56
