### PR TITLE
Allow configurable value for recent view days when getting data from Google Analytics API

### DIFF
--- a/ckanext/googleanalytics/cli.py
+++ b/ckanext/googleanalytics/cli.py
@@ -15,6 +15,7 @@ import ckan.plugins.toolkit as tk
 log = logging.getLogger(__name__)
 PACKAGE_URL = "/dataset/"  # XXX get from routes...
 DEFAULT_RESOURCE_URL_TAG = "/downloads/"
+DEFAULT_RECENT_VIEW_DAYS = 14
 
 RESOURCE_URL_REGEX = re.compile("/dataset/[a-z0-9-_]+/resource/([a-z0-9-_]+)")
 DATASET_EDIT_REGEX = re.compile("/dataset/edit/([a-z0-9-_]+)")
@@ -73,6 +74,12 @@ def _resource_url_tag():
     )
 
 
+def _recent_view_days():
+    return tk.asint(tk.config.get(
+        "googleanalytics.recent_view_days", DEFAULT_RECENT_VIEW_DAYS
+    ))
+
+
 ###############################################################################
 #                                     xxx                                     #
 ###############################################################################
@@ -129,10 +136,10 @@ def internal_save(packages_data, summary_date):
                 SELECT sum(count)
                 FROM tracking_summary t2
                 WHERE t1.url = t2.url
-                AND t2.tracking_date <= t1.tracking_date AND t2.tracking_date >= t1.tracking_date - 14
+                AND t2.tracking_date <= t1.tracking_date AND t2.tracking_date >= t1.tracking_date - %s
              ) + t1.count
              WHERE t1.running_total = 0 AND tracking_type = 'resource';"""
-    engine.execute(sql)
+    engine.execute(sql, self.recent_view_days)
 
     # update summary totals for pages
     sql = """UPDATE tracking_summary t1
@@ -146,12 +153,12 @@ def internal_save(packages_data, summary_date):
                 SELECT sum(count)
                 FROM tracking_summary t2
                 WHERE t1.package_id = t2.package_id
-                AND t2.tracking_date <= t1.tracking_date AND t2.tracking_date >= t1.tracking_date - 14
+                AND t2.tracking_date <= t1.tracking_date AND t2.tracking_date >= t1.tracking_date - %s
              ) + t1.count
              WHERE t1.running_total = 0 AND tracking_type = 'page'
              AND t1.package_id IS NOT NULL
              AND t1.package_id != '~~not~found~~';"""
-    engine.execute(sql)
+    engine.execute(sql, self.recent_view_days)
 
 
 def bulk_import(service, profile_id, start_date=None):
@@ -322,7 +329,7 @@ def get_ga_data(service, profile_id, query_filter):
        {'identifier': {'recent':3, 'ever':6}}
     """
     now = datetime.datetime.now()
-    recent_date = now - datetime.timedelta(14)
+    recent_date = now - datetime.timedelta(self.recent_view_days)
     recent_date = recent_date.strftime("%Y-%m-%d")
     floor_date = datetime.date(2005, 1, 1)
     packages = {}

--- a/ckanext/googleanalytics/cli.py
+++ b/ckanext/googleanalytics/cli.py
@@ -139,7 +139,7 @@ def internal_save(packages_data, summary_date):
                 AND t2.tracking_date <= t1.tracking_date AND t2.tracking_date >= t1.tracking_date - %s
              ) + t1.count
              WHERE t1.running_total = 0 AND tracking_type = 'resource';"""
-    engine.execute(sql, self.recent_view_days)
+    engine.execute(sql, _recent_view_days())
 
     # update summary totals for pages
     sql = """UPDATE tracking_summary t1
@@ -158,7 +158,7 @@ def internal_save(packages_data, summary_date):
              WHERE t1.running_total = 0 AND tracking_type = 'page'
              AND t1.package_id IS NOT NULL
              AND t1.package_id != '~~not~found~~';"""
-    engine.execute(sql, self.recent_view_days)
+    engine.execute(sql, _recent_view_days())
 
 
 def bulk_import(service, profile_id, start_date=None):
@@ -329,7 +329,7 @@ def get_ga_data(service, profile_id, query_filter):
        {'identifier': {'recent':3, 'ever':6}}
     """
     now = datetime.datetime.now()
-    recent_date = now - datetime.timedelta(self.recent_view_days)
+    recent_date = now - datetime.timedelta(_recent_view_days())
     recent_date = recent_date.strftime("%Y-%m-%d")
     floor_date = datetime.date(2005, 1, 1)
     packages = {}


### PR DESCRIPTION
Added new CKAN configurable value for recent view days 'googleanalytics.recent_view_days'.
Default value is still 14 days.
This will allow modifying the packages recent view date day delta.

This is a proposed solution for [Allow configurable value for recent view days when getting data from Google Analytics API](https://github.com/ckan/ckanext-googleanalytics/issues/61)