### PR TITLE
Fix download_handler config option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ retrieves statistics from Google Analytics and inserts them into CKAN pages.
    function must be called instead of `ckan.views.resource:download`
    via `ckanext.googleanalytics.download_handler` config variable. For ckanext-cloudstorage you can use:
 
-		ckanext.googleanalytics.download_handler = ckanext.cloudstorage.views:download
+		googleanalytics.download_handler = ckanext.cloudstorage.views:download
 
 # Domain Linking
 


### PR DESCRIPTION
The config option is actually without ckanext prefix https://github.com/ckan/ckanext-googleanalytics/blob/84c1cf157eab9933f494b71c55808e77d34f6ae8/ckanext/googleanalytics/config.py#L9