### PR TITLE
use HTTPS for www.google.com

### DIFF
--- a/ckanext/googleanalytics/utils.py
+++ b/ckanext/googleanalytics/utils.py
@@ -81,7 +81,7 @@ def _ga_handler(data_dict):
     log.debug("Sending API event to Google Analytics: %s", data)
 
     requests.post(
-        "http://www.google-analytics.com/collect",
+        "https://www.google-analytics.com/collect",
         data,
         timeout=10,
     )


### PR DESCRIPTION
For [our use case](https://github.com/GSA/data.gov/issues/4508), we can't use HTTP. I dont see any reason not using HTTPS for all. 

