### PR TITLE
add user id to api calls

### DIFF
--- a/ckanext/googleanalytics/views.py
+++ b/ckanext/googleanalytics/views.py
@@ -101,6 +101,7 @@ def _post_analytics(
                 "function": request_function,
                 "id": request_id,
                 "payload": request_payload,
+                "user_id": hashlib.md5(six.ensure_binary(tk.c.user)).hexdigest()
             })
 
         else:


### PR DESCRIPTION
Looking to view a user count on api calls to ckan. Still waiting for my test data to come through to GA but seems aligned with the api docs. Could be missing some bits. Please let me know if there is anything else to add to the PR.

https://developers.google.com/analytics/devguides/collection/ga4/uid-data